### PR TITLE
Create DARE.md for City Science Lab project overview

### DIFF
--- a/_posts/DARE.md
+++ b/_posts/DARE.md
@@ -1,0 +1,23 @@
+---
+title: The City Science Lab at work for public health
+image: images/DARE_logo_2.0.png
+author: giulio-colombini
+tags:
+  - DARE
+  - epidemiology
+  - predictive modeling
+  - environmental stress
+  - extreme heat
+  - Large Language Models
+---
+Researchers from the City Science Lab are participating in the [DigitAl lifelong pREvention (DARE) project](https://fondazionedare.it/en) Spoke 2 Pilot action 4.1 _Predictive models for automatic disease surveillance system_.
+
+By leveraging their expertise in understanding complex phenomena, driven by a combination of multiple environmental and social factors, they are developing predictive models for the spread of infectious diseases and extreme heat-related emergency accesses to the hospital.
+Building on the group's [previous work on the COVID-19 pandemic](https://doi.org/10.1186/s12879-025-11520-2), the epidemiological models are being developed with specific attention to accounting for the inter-patient variability of the infectivity period.
+On the other hand, the models under development for Emergency Room visits caused by extreme heat aim to integrate meteorological data with data-oriented discovery of the diagnoses most sensitive to extreme temperatures and social proxies to account for the actual population exposure, which can widely vary during the summer.
+
+While the development of such models is a relevant scientific challenge in itself, our team is also working to integrate them within a user-friendly interface based on agentic AI: in this way the predictive power of complex models and simulations will be made accessible also to clinicians and _decision makers_, so to maximize the positive impact of our research.
+It is well-known that nowadays Large Language Models can write code to perform simple tasks, such as standardized statistical analyses, or data visualizations, but more complex predictive models based on ideas from Complex Systems Physics and Mathematical Biology can be trusted and reliable only when they are developed and validated by experts; for this reason, the system that we are developing is entirely modular with respect to the integration of additional models, which can be built separately and added easily at any time.
+Moreover, in an age of growing concern on privacy and the protection of sensitive data, our system is developed and designed to run entirely on local _offline_ systems, so that no patient data needs to leave the hospital premises during interactions with the agents by the end users.
+
+At present, hospitals and health agencies at many administrative levels are collecting daily great volumes of data, which contain invaluable information for the planning of operations well beyond the routine, provided that appropriate models are used to understand the evolution of data over time and the relationships between different sources. We believe that agentic LLM frameworks can make a difference by making these complex tools available to the professionals who need them the most.


### PR DESCRIPTION
Added a new post about the City Science Lab's work on predictive models for disease surveillance and emergency responses to extreme heat.

This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
